### PR TITLE
add improvements for ivy backend to support user defined actions that access the

### DIFF
--- a/test/xwwp-follow-link-test.el
+++ b/test/xwwp-follow-link-test.el
@@ -108,20 +108,20 @@ return '' + window.location;
        ,@body)))
 
 (ert-deftest test-xwwp-follow-link-prepare-links ()
-  (let ((links '(("3" . "Functions")
-                 ("1" . "Function Cells")
-                 ("12" . "Structures")
-                 ("2" . "Anonymous Functions")
-                 ("9" . "Declare Form"))))
-    (should (equal '(("Function Cells" . 1)
-	             ("Anonymous Functions" . 2)
-	             ("Functions" . 3)
-	             ("Declare Form" . 9)
-	             ("Structures" . 12))
+  (let ((links '(("3" . ["Functions" "http://www.this.is.a.test.de/functions"])
+                 ("1" . ["Function Cells" "http://www.this.is.a.test.de/function-cells"])
+                 ("12" . ["Structures" "http://www.this.is.a.test.de/structures"])
+                 ("2" . ["Anonymous Functions" "http://www.this.is.a.test.de/anon"])
+                 ("9" . ["Declare Form" "http://www.this.is.a.test.de/declare-form"]))))
+    (should (equal '(("Function Cells" . (1 "http://www.this.is.a.test.de/function-cells"))
+	             ("Anonymous Functions" . (2 "http://www.this.is.a.test.de/anon"))
+	             ("Functions" . (3 "http://www.this.is.a.test.de/functions"))
+	             ("Declare Form" . (9 "http://www.this.is.a.test.de/declare-form"))
+	             ("Structures" . (12 "http://www.this.is.a.test.de/structures")))
             (xwwp-follow-link-prepare-links links)))))
 
 (ert-deftest test-xwwp-follow-link-highlight ()
-  (with-test-backend-browse '(0 0 1) 0 "links.html"
+  (with-test-backend-browse '((0 "http://") (0 "http://") (1 "http://")) '(0 "http://") "links.html"
     (xwwp-follow-link)
     (xwwp-event-loop)
     (let ((backend xwwp-follow-link-completion-backend-instance))
@@ -131,7 +131,7 @@ return '' + window.location;
       (should (string= "test-1.html" (file-name-nondirectory (oref backend location))))
       (should (equal (backend-test-link-classes backend "test-1") '["xwwp-follow-link-selected"]))
       (should (equal (backend-test-link-classes backend "test-2") '["xwwp-follow-link-candidate"]))))
-  (with-test-backend-browse '(1 0 1) 1 "links.html"
+  (with-test-backend-browse '((1 "http://") (0 "http://") (1 "http://")) '(1 "http://") "links.html"
     (xwwp-follow-link)
     (xwwp-event-loop)
     (let ((backend xwwp-follow-link-completion-backend-instance))
@@ -140,10 +140,8 @@ return '' + window.location;
       (xwwp-event-dispatch)
       (should (string= "test-2.html" (file-name-nondirectory (oref backend location))))
       (should (equal (backend-test-link-classes backend "test-1") '["xwwp-follow-link-candidate"]))
-      (should (equal (backend-test-link-classes backend "test-2") '["xwwp-follow-link-selected"])))))
-
-(ert-deftest test-xwwp-follow-link-highlight-no-candidates ()
-  (with-test-backend-browse '(1) 1 "links.html"
+      (should (equal (backend-test-link-classes backend "test-2") '["xwwp-follow-link-selected"]))))
+  (with-test-backend-browse '((1 "http://")) '(1 "http://") "links.html"
     (xwwp-follow-link)
     (xwwp-event-loop)
     (let ((backend xwwp-follow-link-completion-backend-instance))

--- a/xwwp-follow-link-helm.el
+++ b/xwwp-follow-link-helm.el
@@ -7,7 +7,7 @@
 ;; Version: 0.1
 ;; Package-Requires: ((emacs "26.1") (xwwp "0.1"))
 
-;; Copyright (C) 2020 Damien Merenne <dam@cosinux.org>
+;; Copyright (C) 2020 Q. Hong <qhong@mit.edu>, Damien Merenne <dam@cosinux.org>
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/xwwp-follow-link-ivy.el
+++ b/xwwp-follow-link-ivy.el
@@ -36,9 +36,14 @@
 (require 'xwwp-follow-link)
 (require 'ivy)
 
+(defvar xwwp-follow-link-ivy-history
+  nil
+  "Stores history for links selected with command `xwwp-follow-link-completion-backend-ivy'.")
+
 (defclass xwwp-follow-link-completion-backend-ivy (xwwp-follow-link-completion-backend) ())
 
 (cl-defmethod xwwp-follow-link-candidates ((_ xwwp-follow-link-completion-backend-ivy))
+  "Follow a link selected with ivy."
   (with-current-buffer (ivy-state-buffer ivy-last)
     (let* ((collection (ivy-state-collection ivy-last))
            (current (ivy-state-current ivy-last))
@@ -47,7 +52,57 @@
       (seq-map (lambda (c) (cdr (nth (get-text-property 0 'idx c) collection))) result))))
 
 (cl-defmethod xwwp-follow-link-read ((_ xwwp-follow-link-completion-backend-ivy) prompt collection action update-fn)
-  (ivy-read prompt collection :require-match t :action (lambda (v) (funcall action (cdr v))) :update-fn update-fn))
+  "Select a link from COLLECTION a with ivy showing PROMPT using UPDATE-FN to highlight the link in the xwidget session and execute ACTION once a link has been select."
+  (ivy-read prompt collection
+            :require-match t
+            :action (lambda (v) (funcall action (cdr v)))
+            :update-fn update-fn
+            :caller 'xwwp-follow-link-read
+            :history 'xwwp-follow-link-ivy-history))
+
+(defmacro xwwp-follow-link-ivy-ivify-action (v &rest body)
+  "Wraps BODY as an action for the `xwwp-follow-link-read' `ivy' version.
+The text and url of the link is made available through variables `linktext' and
+`linkurl' extracted from the selection candidate V.  Before the action is
+executed, the link highlights are removed from the HTML document shown in
+xwidgets."
+  `(let ((xwidget (xwidget-webkit-current-session))
+         (linktext (car ,v))
+         (linkurl (caddr ,v)))
+    (xwwp-follow-link-cleanup xwidget)
+    ,body))
+
+(defun xwwp-follow-link-ivy-copy-url-action (v)
+  "Copy the selected url from candidate V to the `kill-ring'."
+  (xwwp-follow-link-ivy-ivify-action v
+   (ignore 'linktext)
+   (kill-new linkurl)))
+
+(defun xwwp-follow-link-ivy-browse-external-action (v)
+  "Open the selected url from candidate V in the default browser."
+  (xwwp-follow-link-ivy-ivify-action v
+   (ignore 'linktext)
+   (browse-url linkurl)))
+
+(defun xwwp-follow-link-ivy-get-full-candidate (c)
+  "Return the full candidate for a text candidate C from xwwp-follow-link-ivy."
+  (with-current-buffer (ivy-state-buffer ivy-last)
+    (let* ((collection (ivy-state-collection ivy-last)))
+      (nth (get-text-property 0 'idx c) collection))))
+
+(defun xwwp-follow-link-ivy-get-candidate-text (v)
+  "Return the link text for completion candiate V for displaying candidates in `ivy-rich'."
+  (substring-no-properties (car (xwwp-follow-link-ivy-get-full-candidate v))))
+
+(defun xwwp-follow-link-ivy-get-candidate-url (v)
+  "Return the url for for a complettion candidate V for displaying candidates in `ivy-rich'."
+  (caddr (xwwp-follow-link-ivy-get-full-candidate v)))
+
+;; add ivy actions
+(ivy-add-actions
+ 'xwwp-follow-link-read
+ '(("w" xwwp-follow-link-ivy-copy-url-action "Copy URL")
+   ("e" xwwp-follow-link-ivy-browse-external-action "Open in default browser")))
 
 (provide 'xwwp-follow-link-ivy)
 ;;; xwwp-follow-link-ivy.el ends here


### PR DESCRIPTION
URLs of links and for fancier display with ivy rich. Thanks to Q. Hong who
extended xxwp-follow-link to store urls for candidates.


----

#